### PR TITLE
Add support for serving multiple versions

### DIFF
--- a/tensorflow_serving/g3doc/serving_advanced.md
+++ b/tensorflow_serving/g3doc/serving_advanced.md
@@ -143,9 +143,19 @@ With all these, `ServerCore` internally does the following:
   the `SessionBundleSourceAdapter`.
 
 Whenever a new version is available, this `AspiredVersionsManager` always
-unloads the old version and replaces it with the new one. If you want to
+unloads the old version and replaces it with the new one. The default behavior means that
+there will only be one version of the model served at a given time (and that version will be the 
+latest version). The latest version is determined from the model folder name which should be numeric.
+If you would like to serve all the versions available in `model_base_path`, you can set the following environment 
+variable before compiling Tensorflow Serving from source.
+
+~~~
+export TF_SERVING_MULTIPLE_VERSIONS=1
+~~~
+
+If you would to
 start customizing, you are encouraged to understand the components that it
-creates internally, and how to configure them.
+creates internally, and how to configure them. 
 
 It is worth mentioning that TensorFlow Serving is designed from scratch to be
 very flexible and extensible. You can build various plugins to customize system

--- a/tensorflow_serving/g3doc/serving_advanced.md
+++ b/tensorflow_serving/g3doc/serving_advanced.md
@@ -155,7 +155,7 @@ export TF_SERVING_MULTIPLE_VERSIONS=1
 
 If you would to
 start customizing, you are encouraged to understand the components that it
-creates internally, and how to configure them. 
+creates internally, and how to configure them.
 
 It is worth mentioning that TensorFlow Serving is designed from scratch to be
 very flexible and extensible. You can build various plugins to customize system

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -79,7 +79,7 @@ std::set<string> GetDeletedServables(
 
 bool ServeMultipleModelVersions() {
   bool value;
-  Status status = ReadBoolFromEnvVar("TF_SERVING_MULTIPLE_VERSIONS", false, &value);
+  Status status = ReadBoolFromEnvVar("TF_SERVING_MULTIPLE_VERSIONS", true, &value);
 
   if (!status.ok()) {
     LOG(ERROR) << status.error_message();

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -84,6 +84,9 @@ bool ServeMultipleModelVersions() {
   if (!status.ok()) {
     LOG(ERROR) << status.error_message();
   }
+
+  LOG(INFO) << "Should serve multiple model versions:" << value;
+
   return value;
 }
 

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source.cc
@@ -136,6 +136,67 @@ Status PollFileSystemForServable(
   return Status::OK();
 }
 
+Status PollFileSystemForAllServables(
+    const FileSystemStoragePathSourceConfig::ServableToMonitor& servable,
+    std::vector<ServableData<StoragePath>>* versions) {
+  // First, determine whether the base path exists. This check guarantees that
+  // we don't emit an empty aspired-versions list for a non-existent (or
+  // transiently unavailable) base-path. (On some platforms, GetChildren()
+  // returns an empty list instead of erring if the base path isn't found.)
+  if (!Env::Default()->FileExists(servable.base_path())) {
+    return errors::InvalidArgument("Could not find base path ",
+                                   servable.base_path(), " for servable ",
+                                   servable.servable_name());
+  }
+
+  // Retrieve a list of base-path children from the file system.
+  std::vector<string> children;
+  TF_RETURN_IF_ERROR(
+      Env::Default()->GetChildren(servable.base_path(), &children));
+
+  // GetChildren() returns all descendants instead for cloud storage like GCS.
+  // In such case we should filter out all non-direct descendants.
+  std::set<string> real_children;
+  for (int i = 0; i < children.size(); ++i) {
+    const string& child = children[i];
+    real_children.insert(child.substr(0, child.find_first_of('/')));
+  }
+  children.clear();
+  children.insert(children.begin(), real_children.begin(), real_children.end());
+
+  // Identify the all the versions, among children that can be interpreted as
+  // version numbers.
+  int latest_version_child = -1;
+  int64 latest_version;
+  bool model_aspired = false;
+
+  for (int i = 0; i < children.size(); ++i) {
+    const string& child = children[i];
+    int64 child_version_num;
+    if (!strings::safe_strto64(child.c_str(), &child_version_num)) {
+      continue;
+    }
+
+    latest_version_child = i;
+    latest_version = child_version_num;
+    // Emit the aspired-versions data.
+    if (latest_version_child >= 0) {
+      const ServableId servable_id = {servable.servable_name(), latest_version};
+      const string full_path =
+          io::JoinPath(servable.base_path(), children[latest_version_child]);
+      versions->emplace_back(ServableData<StoragePath>(servable_id, full_path));
+      model_aspired = true;
+    }
+  }
+
+  if (!model_aspired) {
+    LOG(WARNING) << "No versions of servable " << servable.servable_name()
+                 << " found under base path " << servable.base_path();
+  }
+
+  return Status::OK();
+}
+
 // Polls the file system, and populates 'versions_by_servable_name' with the
 // aspired-versions data FileSystemStoragePathSource should emit based on what
 // was found, indexed by servable name.
@@ -146,7 +207,7 @@ Status PollFileSystemForConfig(
   for (const FileSystemStoragePathSourceConfig::ServableToMonitor& servable :
        config.servables()) {
     std::vector<ServableData<StoragePath>> versions;
-    TF_RETURN_IF_ERROR(PollFileSystemForServable(servable, &versions));
+    TF_RETURN_IF_ERROR(PollFileSystemForAllServables(servable, &versions));
     versions_by_servable_name->insert(
         {servable.servable_name(), std::move(versions)});
   }

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
@@ -171,10 +171,41 @@ TEST(FileSystemStoragePathSourceTest, MultipleVersions) {
                    .PollFileSystemAndInvokeCallback());
 }
 
+TEST(FileSystemStoragePathSourceTest, MultipleVersionsAtTheSameTime) {
+  const string base_path = io::JoinPath(testing::TmpDir(), "MultipleVersionsAtTheSameTime");
+  TF_ASSERT_OK(Env::Default()->CreateDir(base_path));
+  TF_ASSERT_OK(Env::Default()->CreateDir(
+      io::JoinPath(base_path, "non_numerical_child")));
+  TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "42")));
+  TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "17")));
+  setenv("TF_SERVING_MULTIPLE_VERSIONS","1",1); // Set environment variable to allow multiple versions of model
+
+  auto config = test_util::CreateProto<FileSystemStoragePathSourceConfig>(
+      strings::Printf("servable_name: 'test_servable_name' "
+                      "base_path: '%s' "
+                      // Disable the polling thread.
+                      "file_system_poll_wait_seconds: -1 ",
+                      base_path.c_str()));
+  std::unique_ptr<FileSystemStoragePathSource> source;
+  TF_ASSERT_OK(FileSystemStoragePathSource::Create(config, &source));
+  std::unique_ptr<test_util::MockStoragePathTarget> target(
+      new StrictMock<test_util::MockStoragePathTarget>);
+  ConnectSourceToTarget(source.get(), target.get());
+
+  EXPECT_CALL(*target, SetAspiredVersions(Eq("test_servable_name"),
+                                           ElementsAre(
+                                           ServableData<StoragePath>({"test_servable_name", 17}, io::JoinPath(base_path, "17")),
+                                           ServableData<StoragePath>({"test_servable_name", 42}, io::JoinPath(base_path, "42")))));
+
+  TF_ASSERT_OK(internal::FileSystemStoragePathSourceTestAccess(source.get())
+                   .PollFileSystemAndInvokeCallback());
+}
+
 TEST(FileSystemStoragePathSourceTest, MultipleServables) {
   FileSystemStoragePathSourceConfig config;
   config.set_fail_if_zero_versions_at_startup(false);
   config.set_file_system_poll_wait_seconds(-1);  // Disable the polling thread.
+  setenv("TF_SERVING_MULTIPLE_VERSIONS","0",1); // Set environment variable to allow single version
 
   // Servable 0 has two versions.
   const string base_path_0 =

--- a/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
+++ b/tensorflow_serving/sources/storage_path/file_system_storage_path_source_test.cc
@@ -150,6 +150,7 @@ TEST(FileSystemStoragePathSourceTest, MultipleVersions) {
       io::JoinPath(base_path, "non_numerical_child")));
   TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "42")));
   TF_ASSERT_OK(Env::Default()->CreateDir(io::JoinPath(base_path, "17")));
+  setenv("TF_SERVING_MULTIPLE_VERSIONS","0",1); // Set environment variable to allow single version
 
   auto config = test_util::CreateProto<FileSystemStoragePathSourceConfig>(
       strings::Printf("servable_name: 'test_servable_name' "


### PR DESCRIPTION
/cc @zendesk/bunyip-numbat
### Description

Serve all the versions of models available on the `model_base_path`

Modify `FileSystemStoragePathSource` to emit all versions rather than just the latest version if the following environment variable is set `TF_SERVING_MULTIPLE_VERSIONS` is set to true.
### Related Links:

This is discussed in the following Github issue :
https://github.com/tensorflow/serving/issues/197

Upstream pull request to`tensorflow/serving`:
https://github.com/tensorflow/serving/pull/217
